### PR TITLE
 Update commemorative days data and ical generation script

### DIFF
--- a/calendar.mjs
+++ b/calendar.mjs
@@ -20,7 +20,6 @@ export function generateCalendar(year, month) {
             td.textContent = "";
          } else {
             td.textContent = date;
-            td.textContent = date;
             date++;
          }
 

--- a/days.json
+++ b/days.json
@@ -3,35 +3,35 @@
         "name": "Ada Lovelace Day",
         "monthName": "October",
         "dayName": "Tuesday",
-        "occurence": "second",
+        "occurrence": "second",
         "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/ada.txt"
     },
     {
         "name": "International Binturong Day",
         "monthName": "May",
         "dayName": "Saturday",
-        "occurence": "second",
+        "occurrence": "second",
         "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt"
     },
     {
         "name": "International Vulture Awareness Day",
         "monthName": "September",
         "dayName": "Saturday",
-        "occurence": "first",
+        "occurrence": "first",
         "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/vultures.txt"
     },
     {
         "name": "International Red Panda Day",
         "monthName": "September",
         "dayName": "Saturday",
-        "occurence": "third",
+        "occurrence": "third",
         "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt"
     },
     {
         "name": "World Lemur Day",
         "monthName": "October",
         "dayName": "Friday",
-        "occurence": "last",
+        "occurrence": "last",
         "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt"
     }
 ]

--- a/generate-ical.mjs
+++ b/generate-ical.mjs
@@ -1,9 +1,6 @@
 // generate-ical.mjs
-// You may need to adjust the import based on your specific setup
-// If running in a browser:
+import * as fs from "fs";
 import daysData from "./days.json" with { type: "json" };
-// If running in Node.js
-// import * as fs from 'fs';
 
 // Lookup tables for month and day names
 export const monthNameLookup = {
@@ -124,3 +121,8 @@ END:VEVENT
    return iCalendarContent;
 }
 
+// Generate and save the iCalendar file
+const iCalContent = generateICalContent(daysData);
+
+fs.writeFileSync("commemorative-days.ics", iCalContent);
+console.log("commemorative-days.ics file generated successfully!");


### PR DESCRIPTION
Hi Karla, good minring

I have made 3 updates in the project. I wil have to merge it so I can move on:

1. The error with the dates in the calendar was caused by one date starting on one day and ending on the next. The issue was in the duplicate line of code: 'td.textContent = date;'. It is now fixed.

2- Fixed the "occurence" mispelling on. json

3- Add new code to generate-ical.mjs so we can regenerate the .ics file to fix the bugs. 

talk later. ;)

